### PR TITLE
Add support for sync parameter to Client.jobs.create to allow synchronous job creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,12 @@ Creating an adhoc job::
     >>> print("Job Status: ", job.status)
     Job Status: STARTED
 
+Creating a synchronous adhoc job::
+
+    >>> job = sjs.jobs.create(test_app, class_path, conf=config, sync=True)
+    >>> print(job.result)
+    [2, 4, 6]
+
 Polling for job status::
 
     >>> job = sjs.jobs.create(...)

--- a/sjsclient/job.py
+++ b/sjsclient/job.py
@@ -56,13 +56,14 @@ class JobManager(base.ResourceManager):
         job = self.resource_class(self, data)
         return job
 
-    def create(self, app, class_path, conf=None, ctx=None):
+    def create(self, app, class_path, conf=None, ctx=None, sync=False):
         """Create a Spark job.
 
         :param app: Instance of :class:`App`
         :param class_path: Main class path of spark job.
         :param conf: Configuration json
         :param ctx: Instance of :class:`Context`
+        :param sync: Set to `True` for synchronous job creation
         :rtype: :class:`Job`
         """
 
@@ -71,6 +72,9 @@ class JobManager(base.ResourceManager):
                   'classPath': class_path}
         if ctx:
             params['context'] = ctx.name
+
+        if sync:
+            params['sync'] = 'true'
 
         resp = self.client._post(url, data=conf, params=params).json()
         return self._create_resource(resp)


### PR DESCRIPTION
Hi there — 

This PR adds a `sync` parameter to `Client.jobs.create` to allow synchronous job creation. It simply includes `&sync=true` in the job creation URL if `sync` is set to `True` when creating the job via `Client.jobs.create`. An example is included in `README.rst`.

This should fix #27.

Thanks for your work on this project and open to any and all feedback.