### PR TITLE
Add Client.apps.delete method to allow deleting specific apps

### DIFF
--- a/sjsclient/app.py
+++ b/sjsclient/app.py
@@ -56,6 +56,17 @@ class AppManager(base.ResourceManager):
         time.sleep(1)
         return self.get(name)
 
+    def delete(self, name):
+        """Delete a specific App.
+
+        :param name: The name of the :class:`App` to delete.
+        """
+
+        url = self.base_path
+        url = utils.urljoin(url, name)
+        resp = self.client._delete(url)
+        return resp
+
     def get(self, name):
         """Get a specific App.
 

--- a/sjsclient/tests/functional/test_app.py
+++ b/sjsclient/tests/functional/test_app.py
@@ -5,6 +5,7 @@ from sjsclient import exceptions
 
 from sjsclient.tests.functional import base
 
+import time
 import uuid
 
 
@@ -20,6 +21,16 @@ class TestFunctionalApp(base.TestFunctionalSJS):
         test_app = self.client.apps.create(app_name, self.egg_blob,
                                            app_type=app.AppType.PYTHON)
         return (app_name, test_app)
+
+    def _delete_app(self, name):
+        self.client.apps.delete(name)
+        found = True
+        while found:
+            try:
+                time.sleep(2)
+                self.client.apps.get(name)
+            except exceptions.NotFoundException:
+                found = False
 
     def test_list(self):
         (app_name1, test_app1) = self._create_java_app()
@@ -47,3 +58,9 @@ class TestFunctionalApp(base.TestFunctionalSJS):
     def test_get_non_existing_app(self):
         self.assertRaises(exceptions.NotFoundException,
                           self.client.apps.get, 'does-not-exist')
+
+    def test_delete_app(self):
+        (app_name, test_app) = self._create_java_app()
+        self._delete_app(app_name)
+        self.assertRaises(exceptions.NotFoundException,
+                          self.client.apps.get, app_name)

--- a/sjsclient/tests/unit/test_app.py
+++ b/sjsclient/tests/unit/test_app.py
@@ -77,3 +77,12 @@ class TestApp(base.BaseTestCase):
         app_list = self.client.apps.list()
         for tapp in app_list:
             self.assertAppFields(tapp)
+
+    @requests_mock.Mocker()
+    def test_delete(self, mock_req):
+        get_url = utils.urljoin(self.TEST_ENDPOINT,
+                                self.client.apps.base_path,
+                                app_name)
+
+        mock_req.delete(get_url, text=app_create_response)
+        self.client.apps.delete(app_name)


### PR DESCRIPTION
Hello — 

This PR adds the `Client.apps.delete` method to allow deleting specific apps, which didn't seem to be implemented yet. I modeled the tests after the context deletion tests. 

Open to any and all feedback, thanks.