### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ except ImportError:
     pass
 
 setuptools.setup(
-    setup_requires=['pbr>=1.8'],
+    setup_requires=['pbr>=5.1.0'],
     pbr=True)


### PR DESCRIPTION
pbr version 1.8 doesn't exist. It looks like pbr updated their naming convention and build numbers. This throws off new virtual env builds with python-sjs as a dependency. I've updated the pbr name to a more recent release. This allows all builds to work.